### PR TITLE
Prevent escaping of semi-colon in GEO field

### DIFF
--- a/lib/Data/ICal/Property.pm
+++ b/lib/Data/ICal/Property.pm
@@ -231,7 +231,7 @@ sub _value_as_string {
 
     unless ( $self->vcal10 ) {
         $value =~ s/\\/\\\\/gs;
-        $value =~ s/;/\\;/gs unless lc($key) eq 'rrule';
+        $value =~ s/;/\\;/gs unless lc($key) eq 'rrule' || lc($key) eq 'geo';
         $value =~ s/,/\\,/gs unless lc($key) eq 'rrule';
         $value =~ s/\x0d?\x0a/\\n/gs;
     }

--- a/t/01.simplegen.t
+++ b/t/01.simplegen.t
@@ -80,6 +80,7 @@ can_ok($event, qw/add_property add_properties properties/);
 $event->add_properties( 
                         summary => 'Awesome party',
                         description => "at my \\ place,\nOn 5th St.;",
+                        geo => '123.000;-0.001',
                     );
 
 ok($s->add_entry($event));
@@ -97,6 +98,7 @@ URL:http://example.com/todo1
 END:VTODO
 BEGIN:VEVENT
 DESCRIPTION:at my \\\\ place\\,\\nOn 5th St.\\;
+GEO:123.000\;-0.001
 SUMMARY:Awesome party
 END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION
This addresses issue 131339 on RT
(https://rt.cpan.org/Ticket/Display.html?id=131339)

The _value_as_string sub in Data::ICal::Property escapes ";" to "\;"
This is not desired behavior in the GEO param, so I add an additional
clause to the existing logic to prevent it.